### PR TITLE
Fix `denominator` computation in `KDense`

### DIFF
--- a/src/kdense.jl
+++ b/src/kdense.jl
@@ -24,7 +24,7 @@ function KDense(
     #
     normalizer = tanh,
     grid_lims::NTuple{2, Real} = (-1.0f0, 1.0f0),
-    denominator = Float32(2 / (grid_len - 1)),
+    denominator = nothing,
     #
     basis_func = rbf,
     #
@@ -47,7 +47,7 @@ function KDense(
         end
     end
 
-    grid_span =  grid_lims[2] > grid_lims[1]
+    grid_span =  grid_lims[2] - grid_lims[1]
     @assert grid_span > 0
 
     if isnothing(denominator)


### PR DESCRIPTION
* Fix computation of `grid_span`.
* Use `denominator=nothing` as kwarg default to choose a reasonable denominator if `grid_lims` are chosen other than `(-1, 1)`. Note: this will modify the behavior for `normalizer ∈ (sigmoid, sigmoid_fast)` and `grid_lims=nothing`, changing denominator from `2/(grid_len-1)` to `1/(grid_len-1)`.

Hit this when trying to work with custom `grid_lims`, which without this change requires passing a handcrafted `denominator` to work properly.